### PR TITLE
Make aquatic campaign more aquatic

### DIFF
--- a/src/subvoyage/content/block/SvBlocks.java
+++ b/src/subvoyage/content/block/SvBlocks.java
@@ -1898,6 +1898,7 @@ public class SvBlocks{
             envDisabled |= Env.scorching;
             unitCapModifier = 12;
 
+            placeableLiquid = true;
             bannedItems.addAll(crude);
         }
 
@@ -1923,6 +1924,7 @@ public class SvBlocks{
             envDisabled |= Env.scorching;
             unitCapModifier = 18;
 
+            placeableLiquid = true;
             bannedItems.addAll(crude);
         }
 
@@ -1947,6 +1949,7 @@ public class SvBlocks{
             envDisabled |= Env.scorching;
             unitCapModifier = 30;
 
+            placeableLiquid = true;
             bannedItems.addAll(crude);
         }
 
@@ -1999,6 +2002,7 @@ public class SvBlocks{
             ((Duct) duct).bridgeReplacement = this;
             ((Duct) highPressureDuct).bridgeReplacement = this;
 
+            placeableLiquid = true;
             envDisabled |= Env.scorching;
             health = 90;
             speed = 4f;


### PR DESCRIPTION
Mapgen currently can put deep water on every tile that touches the core. When that happens, you cannot upgrade the core, and ducts cannot carry anything into the core.

I am suggesting a bare minimum fix, that will also help use more of the terrain:

Set `placeableLiquid = true;` on cores and on the duct bridge. 